### PR TITLE
Date Range handler

### DIFF
--- a/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
+++ b/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
@@ -120,7 +120,7 @@ namespace OpenElectricity.Sdk.Benchmark
             try
             {
 
-                var market_data = _client.GetGenerationDataForDateRangeAsync(
+                var market_data = _client.GetGenerationData(
                     networkCode: networkCode,
                     metrics: [metric],
                     interval: interval,
@@ -128,9 +128,9 @@ namespace OpenElectricity.Sdk.Benchmark
                     dateEnd: end,
                     cancellationToken: cancellationToken);
 
-                await foreach (var page in market_data)
+                foreach (var page in market_data)
                 {
-                    var network = page.FirstOrDefault();
+                    var network = (await page).FirstOrDefault();
                     if (network is null) continue;
 
                     DateTimeOffset page_start = network.DateStart;

--- a/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
+++ b/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
-using OpenElectricity.Sdk.Models;
+using OpenElectricity.Sdk.Client;
+using OpenElectricity.Sdk.Types;
 using System.Text;
 using System.Threading;
 
@@ -172,6 +173,42 @@ namespace OpenElectricity.Sdk.Benchmark
                 return false;
             }
             return true;
+        }
+
+        private async Task<List<NetworkData>> GetGenerationDataForDateRangeAsync(
+            NetworkCode networkCode,
+            List<DataMetric> metrics,
+            DataInterval interval,
+            DateTime dateStart,
+            DateTime dateEnd,
+            DataPrimaryGrouping? primaryGrouping = null,
+            DataSecondaryGrouping? secondaryGrouping = null,
+            bool withClerk = true,
+            CancellationToken cancellationToken = default
+
+            )
+        {
+            int dayRange = interval.DayRange() ?? throw new Exception($"Day range for interval {interval} is invalid");
+
+            List<Task<List<NetworkData>>> tasks = [];
+            DateTime currentStart = dateStart;
+            while(currentStart < dateEnd)
+            {
+                DateTime currentEnd = currentStart.AddDays(dayRange);
+                if (currentEnd > dateEnd)
+                {
+                    currentEnd = dateEnd;
+                }
+
+                Task<List<NetworkData>> task = _client.GetGenerationDataAsync(
+                    networkCode, metrics, interval, currentStart, currentEnd, 
+                    primaryGrouping, secondaryGrouping, withClerk, 
+                    cancellationToken);
+                tasks.Add(task);
+            }
+
+            List<NetworkData>[]? results = await Task.WhenAll(tasks);
+            return [..results.SelectMany(r => r)];
         }
     }
 }

--- a/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
+++ b/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
@@ -2,7 +2,6 @@
 using OpenElectricity.Sdk.Client;
 using OpenElectricity.Sdk.Types;
 using System.Text;
-using System.Threading;
 
 namespace OpenElectricity.Sdk.Benchmark
 {
@@ -96,45 +95,34 @@ namespace OpenElectricity.Sdk.Benchmark
         {
             NetworkCode networkCode = NetworkCode.NEM;
             DataMetric metric = DataMetric.energy;
+            DataInterval interval = DataInterval.OneHour;
 
-            //var me = await _client.GetUserAsync(cancellationToken: cancellationToken);
+            User? me = await _client.GetUserAsync(cancellationToken: cancellationToken);
 
-            List<Task> tasks = [];
-            DateTime currentStart = start;
-            while(currentStart < end)
-            {
-                DateTime currentEnd = currentStart.AddDays(30);
-                if (currentEnd > end)
-                {
-                    currentEnd = end;
-                }
+            _logger.LogInformation("User token granted for {username}", me.Email);
 
-                var task = Fetch30Days(folderPath, networkCode, metric, currentStart, currentEnd, cancellationToken);
-                tasks.Add(task);
-                //await task;
+            bool result = await FetchAll(folderPath, networkCode, metric, interval, start, end, cancellationToken);
 
-                currentStart = currentStart.AddDays(30);
-            }
-
-            await Task.WhenAll(tasks);
+            _logger.LogInformation("Result is {result}", result);
 
             return;
         }
 
-        private async Task<bool> Fetch30Days(
+        private async Task<bool> FetchAll(
             string folderPath,
             NetworkCode networkCode, 
             DataMetric metric, 
+            DataInterval interval,
             DateTime start, 
             DateTime end,
             CancellationToken cancellationToken = default)
         {
             try
             {
-                var market_data = await _client.GetGenerationDataAsync(
+                var market_data = await _client.GetGenerationDataForDateRangeAsync(
                     networkCode: networkCode,
                     metrics: [metric],
-                    interval: DataInterval.OneHour,
+                    interval: interval,
                     dateStart: start,
                     dateEnd: end,
                     cancellationToken: cancellationToken);
@@ -173,58 +161,6 @@ namespace OpenElectricity.Sdk.Benchmark
                 return false;
             }
             return true;
-        }
-
-        private async Task<List<NetworkData>> GetGenerationDataForDateRangeAsync(
-            NetworkCode networkCode,
-            List<DataMetric> metrics,
-            DataInterval interval,
-            DateTime dateStart,
-            DateTime dateEnd,
-            DataPrimaryGrouping? primaryGrouping = null,
-            DataSecondaryGrouping? secondaryGrouping = null,
-            bool withClerk = true,
-            CancellationToken cancellationToken = default
-
-            )
-        {
-            return await GetAllForTimeRangeAsync((inter, start, end, token) =>
-            {
-                return _client.GetGenerationDataAsync(
-                    networkCode, metrics, inter, start, end,
-                    primaryGrouping, secondaryGrouping, withClerk,
-                    token);
-            },
-            interval, dateStart, dateEnd, cancellationToken);
-        }
-
-        private static async Task<List<NetworkData>> GetAllForTimeRangeAsync(
-            Func<DataInterval, DateTime, DateTime, CancellationToken, Task<List<NetworkData>>> getDataFunction,
-            DataInterval interval,
-            DateTime start, 
-            DateTime end,
-            CancellationToken cancellationToken = default
-            )
-        {
-
-            int dayRange = interval.DayRange() ?? throw new Exception($"Day range for interval {interval} is invalid");
-
-            List<Task<List<NetworkData>>> tasks = [];
-            DateTime currentStart = start;
-            while (currentStart < end)
-            {
-                DateTime currentEnd = currentStart.AddDays(dayRange);
-                if (currentEnd > end)
-                {
-                    currentEnd = end;
-                }
-
-                Task<List<NetworkData>> task = getDataFunction(interval, currentStart, currentEnd, cancellationToken);
-                tasks.Add(task);
-            }
-
-            List<NetworkData>[]? results = await Task.WhenAll(tasks);
-            return [.. results.SelectMany(r => r)];
         }
     }
 }

--- a/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
+++ b/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
@@ -2,6 +2,7 @@
 using OpenElectricity.Sdk.Client;
 using OpenElectricity.Sdk.Types;
 using System.Text;
+using System.Threading;
 
 namespace OpenElectricity.Sdk.Benchmark
 {
@@ -187,27 +188,43 @@ namespace OpenElectricity.Sdk.Benchmark
 
             )
         {
+            return await GetAllForTimeRangeAsync((inter, start, end, token) =>
+            {
+                return _client.GetGenerationDataAsync(
+                    networkCode, metrics, inter, start, end,
+                    primaryGrouping, secondaryGrouping, withClerk,
+                    token);
+            },
+            interval, dateStart, dateEnd, cancellationToken);
+        }
+
+        private static async Task<List<NetworkData>> GetAllForTimeRangeAsync(
+            Func<DataInterval, DateTime, DateTime, CancellationToken, Task<List<NetworkData>>> getDataFunction,
+            DataInterval interval,
+            DateTime start, 
+            DateTime end,
+            CancellationToken cancellationToken = default
+            )
+        {
+
             int dayRange = interval.DayRange() ?? throw new Exception($"Day range for interval {interval} is invalid");
 
             List<Task<List<NetworkData>>> tasks = [];
-            DateTime currentStart = dateStart;
-            while(currentStart < dateEnd)
+            DateTime currentStart = start;
+            while (currentStart < end)
             {
                 DateTime currentEnd = currentStart.AddDays(dayRange);
-                if (currentEnd > dateEnd)
+                if (currentEnd > end)
                 {
-                    currentEnd = dateEnd;
+                    currentEnd = end;
                 }
 
-                Task<List<NetworkData>> task = _client.GetGenerationDataAsync(
-                    networkCode, metrics, interval, currentStart, currentEnd, 
-                    primaryGrouping, secondaryGrouping, withClerk, 
-                    cancellationToken);
+                Task<List<NetworkData>> task = getDataFunction(interval, currentStart, currentEnd, cancellationToken);
                 tasks.Add(task);
             }
 
             List<NetworkData>[]? results = await Task.WhenAll(tasks);
-            return [..results.SelectMany(r => r)];
+            return [.. results.SelectMany(r => r)];
         }
     }
 }

--- a/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
+++ b/OpenElectricity.Sdk.Benchmark/HostedTesting.cs
@@ -99,7 +99,7 @@ namespace OpenElectricity.Sdk.Benchmark
 
             User? me = await _client.GetUserAsync(cancellationToken: cancellationToken);
 
-            _logger.LogInformation("User token granted for {username}", me.Email);
+            _logger.LogInformation("User token granted for {username}", me?.Email ?? "[Unable to get user details]");
 
             bool result = await FetchAll(folderPath, networkCode, metric, interval, start, end, cancellationToken);
 
@@ -119,7 +119,8 @@ namespace OpenElectricity.Sdk.Benchmark
         {
             try
             {
-                var market_data = await _client.GetGenerationDataForDateRangeAsync(
+
+                var market_data = _client.GetGenerationDataForDateRangeAsync(
                     networkCode: networkCode,
                     metrics: [metric],
                     interval: interval,
@@ -127,30 +128,38 @@ namespace OpenElectricity.Sdk.Benchmark
                     dateEnd: end,
                     cancellationToken: cancellationToken);
 
-                var emissions = market_data.FirstOrDefault(r => r.Metric == (Metric)metric)?.Results.FirstOrDefault()?.Data ?? [];
-
-                string outputFile = $"{networkCode}.{metric}_{start:yyyyMMddHHmmss}-{end:yyyyMMddHHmmss}.csv";
-
-                string filePath = Path.Combine(folderPath, outputFile);
-                FileInfo file = new(filePath);
-                if (file.Directory is not null && !file.Directory.Exists)
+                await foreach (var page in market_data)
                 {
-                    Directory.CreateDirectory(file.Directory.FullName);
-                }
-                if (file.Exists)
-                {
-                    File.Delete(file.FullName);
-                }
+                    var network = page.FirstOrDefault();
+                    if (network is null) continue;
 
-                using FileStream fileStream = new(file.FullName, FileMode.Create, FileAccess.ReadWrite);
-                using StreamWriter streamWriter = new(fileStream, Encoding.UTF8);
+                    DateTimeOffset page_start = network.DateStart;
+                    DateTimeOffset page_end = network.DateEnd;
+                    var data = network?.Results.FirstOrDefault()?.Data ?? [];
 
-                string header = "Region, DateTime, Value";
-                streamWriter.WriteLine(header);
+                    string outputFile = $"{networkCode}.{metric}_{page_start:yyyyMMddHHmmss}-{page_end:yyyyMMddHHmmss}.csv";
 
-                foreach (var tv in emissions)
-                {
-                    streamWriter.WriteLine($"{tv.Timestamp:s}, {tv.Value}");
+                    string filePath = Path.Combine(folderPath, outputFile);
+                    FileInfo file = new(filePath);
+                    if (file.Directory is not null && !file.Directory.Exists)
+                    {
+                        Directory.CreateDirectory(file.Directory.FullName);
+                    }
+                    if (file.Exists)
+                    {
+                        File.Delete(file.FullName);
+                    }
+
+                    using FileStream fileStream = new(file.FullName, FileMode.Create, FileAccess.ReadWrite);
+                    using StreamWriter streamWriter = new(fileStream, Encoding.UTF8);
+
+                    string header = "Region, DateTime, Value";
+                    streamWriter.WriteLine(header);
+
+                    foreach (var tv in data)
+                    {
+                        streamWriter.WriteLine($"{tv.Timestamp:s}, {tv.Value}");
+                    }
                 }
 
                 _logger.LogDebug("GetMarketData success");

--- a/OpenElectricity.Sdk.Benchmark/Program.cs
+++ b/OpenElectricity.Sdk.Benchmark/Program.cs
@@ -23,7 +23,7 @@ namespace OpenElectricity.Sdk.Benchmark
 
             await testing.RunCarbonDataFetchAsync(
                 DateTime.Parse("2023-01-01"),
-                DateTime.Parse("2025-01-01"),
+                DateTime.Parse("2023-04-01"),
                 "C:\\Users\\AlexHoffman\\Downloads\\OpenElectricityData"
                 );
             return;

--- a/OpenElectricity.Sdk.Benchmark/Program.cs
+++ b/OpenElectricity.Sdk.Benchmark/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenElectricity.Sdk.Client;
 
 namespace OpenElectricity.Sdk.Benchmark
 {
@@ -11,6 +12,8 @@ namespace OpenElectricity.Sdk.Benchmark
 
             builder.Services.UseOpenElectricityClient(builder.Configuration);
             builder.Services.AddScoped<HostedTesting>();
+
+            var builder2 = Host.CreateDefaultBuilder(args);
 
             var app = builder.Build();
 

--- a/OpenElectricity.Sdk/Client/OpenElectricityClient.cs
+++ b/OpenElectricity.Sdk/Client/OpenElectricityClient.cs
@@ -87,7 +87,7 @@ namespace OpenElectricity.Sdk.Client
             }
             catch (Exception ex)
             {
-                throw new Exception($"Unhandled exception when executing {request.RequestUri}", ex);
+                throw new Exception($"Unhandled exception when executing {request.RequestUri}; {await response.Content.ReadAsStringAsync(cancellationToken)}", ex);
             }
             finally
             {

--- a/OpenElectricity.Sdk/Client/OpenElectricityClient.cs
+++ b/OpenElectricity.Sdk/Client/OpenElectricityClient.cs
@@ -157,7 +157,7 @@ namespace OpenElectricity.Sdk.Client
         /// <returns></returns>
         /// <exception cref="HttpRequestException">If there is an error during the request, or if the request returns an error status code</exception>
         /// <exception cref="JsonException">If there is an error when deserializing</exception>
-        public async Task<User> GetUserAsync(
+        public async Task<User?> GetUserAsync(
             bool withClerk = true,
             CancellationToken cancellationToken = default
             )
@@ -208,7 +208,7 @@ namespace OpenElectricity.Sdk.Client
 
             HttpRequestMessage request = new(HttpMethod.Get, $"{route}{parameters}");
 
-            return await SendAsync<List<Facility>>(request, cancellationToken);
+            return await SendAsync<List<Facility>>(request, cancellationToken) ?? [];
         }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace OpenElectricity.Sdk.Client
 
             HttpRequestMessage request = new(HttpMethod.Get, $"{route}{parameters}");
 
-            return await SendAsync<List<NetworkData>>(request, cancellationToken);
+            return await SendAsync<List<NetworkData>>(request, cancellationToken) ?? [];
         }
 
         /// <summary>
@@ -291,7 +291,7 @@ namespace OpenElectricity.Sdk.Client
 
             HttpRequestMessage request = new(HttpMethod.Get, $"{route}{parameters}");
 
-            return await SendAsync<List<NetworkData>>(request, cancellationToken);
+            return await SendAsync<List<NetworkData>>(request, cancellationToken) ?? [];
 
         }
 
@@ -332,7 +332,7 @@ namespace OpenElectricity.Sdk.Client
 
             HttpRequestMessage request = new(HttpMethod.Get, $"{route}{parameters}");
 
-            return await SendAsync<List<NetworkData>>(request, cancellationToken);
+            return await SendAsync<List<NetworkData>>(request, cancellationToken) ?? [];
         }
     }
 }

--- a/OpenElectricity.Sdk/Client/OpenElectricityClient.cs
+++ b/OpenElectricity.Sdk/Client/OpenElectricityClient.cs
@@ -4,6 +4,7 @@ using OpenElectricity.Sdk.Types;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading;
 
 namespace OpenElectricity.Sdk.Client
 {
@@ -43,7 +44,49 @@ namespace OpenElectricity.Sdk.Client
             _httpClient.ConfigureDefaultHttpClient(options.Value);
         }
 
-        private async Task<T> SendAsync<T>(
+        /// <summary>
+        /// Handles sending the request
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="JsonException"></exception>
+        /// <exception cref="HttpRequestException"></exception>
+        /// <exception cref="Exception"></exception>
+        private async Task<T?> SendAsync<T>(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpResponseMessage response = await SendAsync(request, cancellationToken);
+            APIResponse<T> result;
+            try 
+            { 
+                result = await DeserializeAsync<T>(response, cancellationToken);
+            }
+            catch(HttpRequestException)
+            {
+                throw;
+            }
+            catch (JsonException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Unhandled exception when executing {request.RequestUri}; Response was {await response.Content.ReadAsStringAsync(cancellationToken)}", ex);
+            }
+
+            return result.Data;
+        }
+
+        /// <summary>
+        /// Handles sending the actual request
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken = default)
         {
@@ -56,45 +99,53 @@ namespace OpenElectricity.Sdk.Client
                 }
             }
 
-            var response = await _httpClient.SendAsync(request, cancellationToken);
-            APIResponse<T> result;
-            try
-            {
-                if (response.StatusCode == HttpStatusCode.UnprocessableContent)
-                {
-                    var error = await response.Content.ReadFromJsonAsync<Error422Response>(_serializerOptions, cancellationToken)
-                        ?? throw new JsonException($"Unable to deserialize response with status code {response.StatusCode}");
+            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
 
-                    throw new HttpRequestException($"Request failed with status code {response.StatusCode}. Reason: {error.Detail?.FirstOrDefault()?.Msg}");
-                }
-
-                result = await response.Content.ReadFromJsonAsync<APIResponse<T>>(_serializerOptions, cancellationToken)
-                    ?? throw new JsonException($"Unable to deserialize response with status code {response.StatusCode}");
-
-                if (!result.Success)
-                {
-                    throw new HttpRequestException($"Request failed with status code {response.StatusCode}. Reason: {result.Error}");
-                }
-                if (result.Data is null)
-                {
-                    throw new JsonException($"Unable to deserialize response with status code {response.StatusCode}");
-                }
-
-                if (!hasfirstRequestFinished)
-                {
-                    hasfirstRequestFinished = true;
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new Exception($"Unhandled exception when executing {request.RequestUri}; {await response.Content.ReadAsStringAsync(cancellationToken)}", ex);
-            }
-            finally
+            if (!hasfirstRequestFinished)
             {
                 _semaphore.Release();
+                hasfirstRequestFinished = true;
             }
 
-            return result.Data;
+            return response;
+        }
+
+
+        /// <summary>
+        /// Handles the deserialization of HttpResponseMessage using the defined types
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="response"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="JsonException"></exception>
+        /// <exception cref="HttpRequestException"></exception>
+        private async Task<APIResponse<T>> DeserializeAsync<T>(
+            HttpResponseMessage response,
+            CancellationToken cancellationToken = default)
+        {
+            APIResponse<T> result;
+            if (response.StatusCode == HttpStatusCode.UnprocessableContent)
+            {
+                var error = await response.Content.ReadFromJsonAsync<Error422Response>(_serializerOptions, cancellationToken)
+                    ?? throw new JsonException($"Unable to deserialize response with status code {response.StatusCode}");
+
+                throw new HttpRequestException($"Request failed with status code {response.StatusCode}. Reason: {error.Detail?.FirstOrDefault()?.Msg}");
+            }
+
+            result = await response.Content.ReadFromJsonAsync<APIResponse<T>>(_serializerOptions, cancellationToken)
+                ?? throw new JsonException($"Unable to deserialize response with status code {response.StatusCode}");
+
+            if (!result.Success)
+            {
+                throw new HttpRequestException($"Request failed with status code {response.StatusCode}. Reason: {result.Error}");
+            }
+            if (result.Data is null)
+            {
+                throw new JsonException($"Unable to deserialize response with status code {response.StatusCode}");
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
+++ b/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
@@ -159,6 +159,10 @@ namespace OpenElectricity.Sdk.Client
             }
 
             List<NetworkData>[]? results = await Task.WhenAll(tasks);
+
+            // BUG: Currently this just combines the responses of all the separate requests into a list
+            // EXPECTED: Combines List<TimeValue> together based on NetworkData.NetworkCode + NetworkData.Groupings + TimeSeriesResult.Name + TimeSeriesResult.Columns
+
             return [.. results.SelectMany(r => r)];
         }
     }

--- a/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
+++ b/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
@@ -22,7 +22,7 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public static async IAsyncEnumerable<List<NetworkData>> GetMarketDataForDateRangeAsync(
+        public static IEnumerable<Task<List<NetworkData>>> GetMarketData(
             this OpenElectricityClient client,
             NetworkCode networkCode,
             List<MarketMetric> metrics,
@@ -31,22 +31,17 @@ namespace OpenElectricity.Sdk.Client
             DateTime dateEnd,
             DataPrimaryGrouping? primaryGrouping = null,
             bool withClerk = true,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default
             )
         {
-            var enumerator = GetAllForDateRangeAsync((inter, start, end, token) =>
+            return GenerateTasksForDateRange((inter, start, end) =>
             {
                 return client.GetMarketDataAsync(
                     networkCode, metrics, inter, start, end,
                     primaryGrouping, withClerk,
-                    token);
+                    cancellationToken);
             },
-            interval, dateStart, dateEnd, cancellationToken);
-
-            await foreach (var page in enumerator)
-            {
-                yield return page;
-            }
+            interval, dateStart, dateEnd);
         }
 
         /// <summary>
@@ -64,7 +59,7 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public static async IAsyncEnumerable<List<NetworkData>> GetGenerationDataForDateRangeAsync(
+        public static IEnumerable<Task<List<NetworkData>>> GetGenerationData(
             this OpenElectricityClient client,
             NetworkCode networkCode,
             List<DataMetric> metrics,
@@ -74,22 +69,17 @@ namespace OpenElectricity.Sdk.Client
             DataPrimaryGrouping? primaryGrouping = null,
             DataSecondaryGrouping? secondaryGrouping = null,
             bool withClerk = true,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default
             )
         {
-            var enumerator = GetAllForDateRangeAsync((inter, start, end, token) =>
+            return GenerateTasksForDateRange((inter, start, end) =>
             {
                 return client.GetGenerationDataAsync(
                     networkCode, metrics, inter, start, end,
                     primaryGrouping, secondaryGrouping, withClerk,
-                    token);
+                    cancellationToken);
             },
-            interval, dateStart, dateEnd, cancellationToken);
-
-            await foreach(var page in enumerator)
-            {
-                yield return page;
-            }
+            interval, dateStart, dateEnd);
         }
 
         /// <summary>
@@ -105,7 +95,7 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="withClerk"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async IAsyncEnumerable<List<NetworkData>> GetFacilityDataForDateRangeAsync(
+        public static IEnumerable<Task<List<NetworkData>>> GetFacilityDataForDateRangeAsync(
             this OpenElectricityClient client,
             NetworkCode networkCode,
             List<DataMetric> metrics,
@@ -114,22 +104,17 @@ namespace OpenElectricity.Sdk.Client
             DateTime dateEnd,
             List<string>? facilityCodes = null,
             bool withClerk = true,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default
             )
         {
-            var enumerator = GetAllForDateRangeAsync((inter, start, end, token) =>
+            return GenerateTasksForDateRange((inter, start, end) =>
             {
                 return client.GetFacilityDataAsync(
                     networkCode, metrics, inter, facilityCodes, 
                     start, end, withClerk,
-                    token);
+                    cancellationToken);
             },
-            interval, dateStart, dateEnd, cancellationToken);
-
-            await foreach (var page in enumerator)
-            {
-                yield return page;
-            }
+            interval, dateStart, dateEnd);
         }
 
         /// <summary>
@@ -139,15 +124,13 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="interval"></param>
         /// <param name="start"></param>
         /// <param name="end"></param>
-        /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public static async IAsyncEnumerable<List<NetworkData>> GetAllForDateRangeAsync(
-            Func<DataInterval, DateTime, DateTime, CancellationToken, Task<List<NetworkData>>> getDataFunction,
+        public static IEnumerable<Task<List<NetworkData>>> GenerateTasksForDateRange(
+            Func<DataInterval, DateTime, DateTime, Task<List<NetworkData>>> getDataFunction,
             DataInterval interval,
             DateTime start,
-            DateTime end,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default
+            DateTime end
             )
         {
             int dayRange = interval.DayRange() ?? throw new Exception($"Day range for interval {interval} is invalid");
@@ -156,7 +139,6 @@ namespace OpenElectricity.Sdk.Client
                 throw new Exception($"Day range of [{dayRange}] for interval {interval} is invalid");
             }
 
-            List<Task<List<NetworkData>>> tasks = [];
             DateTime currentStart = start;
             while (currentStart < end)
             {
@@ -166,14 +148,10 @@ namespace OpenElectricity.Sdk.Client
                     currentEnd = end;
                 }
 
-                Task<List<NetworkData>> task = getDataFunction(interval, currentStart, currentEnd, cancellationToken);
-                tasks.Add(task);
+                Task<List<NetworkData>> task = getDataFunction(interval, currentStart, currentEnd);
                 currentStart = currentEnd;
-            }
 
-            await foreach(var response in Task.WhenEach(tasks))
-            {
-                yield return await response;
+                yield return task;
             }
         }
     }

--- a/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
+++ b/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
@@ -1,0 +1,165 @@
+﻿using OpenElectricity.Sdk.Types;
+
+namespace OpenElectricity.Sdk.Client
+{
+    /// <summary>
+    /// Set of helper extensions for fetching and processing data using the <see cref="OpenElectricityClient"/>
+    /// </summary>
+    public static class OpenElectricityClientExtensions
+    {
+        /// <summary>
+        /// Get market data for a network. Sends multiple requests if the date range is too large for the interval
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="networkCode"></param>
+        /// <param name="metrics"></param>
+        /// <param name="interval"></param>
+        /// <param name="dateStart"></param>
+        /// <param name="dateEnd"></param>
+        /// <param name="primaryGrouping"></param>
+        /// <param name="withClerk"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public static async Task<List<NetworkData>> GetMarketDataForDateRangeAsync(
+            this OpenElectricityClient client,
+            NetworkCode networkCode,
+            List<MarketMetric> metrics,
+            DataInterval interval,
+            DateTime dateStart,
+            DateTime dateEnd,
+            DataPrimaryGrouping? primaryGrouping = null,
+            bool withClerk = true,
+            CancellationToken cancellationToken = default
+
+            )
+        {
+            return await GetAllForDateRangeAsync((inter, start, end, token) =>
+            {
+                return client.GetMarketDataAsync(
+                    networkCode, metrics, inter, start, end,
+                    primaryGrouping, withClerk,
+                    token);
+            },
+            interval, dateStart, dateEnd, cancellationToken);
+        }
+
+        /// <summary>
+        /// Get time series data for a network. Sends multiple requests if the date range is too large for the interval
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="networkCode"></param>
+        /// <param name="metrics"></param>
+        /// <param name="interval"></param>
+        /// <param name="dateStart"></param>
+        /// <param name="dateEnd"></param>
+        /// <param name="primaryGrouping"></param>
+        /// <param name="secondaryGrouping"></param>
+        /// <param name="withClerk"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public static async Task<List<NetworkData>> GetGenerationDataForDateRangeAsync(
+            this OpenElectricityClient client,
+            NetworkCode networkCode,
+            List<DataMetric> metrics,
+            DataInterval interval,
+            DateTime dateStart,
+            DateTime dateEnd,
+            DataPrimaryGrouping? primaryGrouping = null,
+            DataSecondaryGrouping? secondaryGrouping = null,
+            bool withClerk = true,
+            CancellationToken cancellationToken = default
+
+            )
+        {
+            return await GetAllForDateRangeAsync((inter, start, end, token) =>
+            {
+                return client.GetGenerationDataAsync(
+                    networkCode, metrics, inter, start, end,
+                    primaryGrouping, secondaryGrouping, withClerk,
+                    token);
+            },
+            interval, dateStart, dateEnd, cancellationToken);
+        }
+
+        /// <summary>
+        /// Get time series data for a specific facility. Sends multiple requests if the date range is too large for the interval
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="networkCode"></param>
+        /// <param name="metrics"></param>
+        /// <param name="interval"></param>
+        /// <param name="dateStart"></param>
+        /// <param name="dateEnd"></param>
+        /// <param name="facilityCodes"></param>
+        /// <param name="withClerk"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static async Task<List<NetworkData>> GetFacilityDataForDateRangeAsync(
+            this OpenElectricityClient client,
+            NetworkCode networkCode,
+            List<DataMetric> metrics,
+            DataInterval interval,
+            DateTime dateStart,
+            DateTime dateEnd,
+            List<string>? facilityCodes = null,
+            bool withClerk = true,
+            CancellationToken cancellationToken = default
+
+            )
+        {
+            return await GetAllForDateRangeAsync((inter, start, end, token) =>
+            {
+                return client.GetFacilityDataAsync(
+                    networkCode, metrics, inter, facilityCodes, 
+                    start, end, withClerk,
+                    token);
+            },
+            interval, dateStart, dateEnd, cancellationToken);
+        }
+
+        /// <summary>
+        /// Helper function to fetch all data for the provided <see cref="DataInterval"/> between two timestamps.
+        /// </summary>
+        /// <param name="getDataFunction"></param>
+        /// <param name="interval"></param>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public static async Task<List<NetworkData>> GetAllForDateRangeAsync(
+            Func<DataInterval, DateTime, DateTime, CancellationToken, Task<List<NetworkData>>> getDataFunction,
+            DataInterval interval,
+            DateTime start,
+            DateTime end,
+            CancellationToken cancellationToken = default
+            )
+        {
+            int dayRange = interval.DayRange() ?? throw new Exception($"Day range for interval {interval} is invalid");
+            if (dayRange <= 0)
+            {
+                throw new Exception($"Day range of [{dayRange}] for interval {interval} is invalid");
+            }
+
+            List<Task<List<NetworkData>>> tasks = [];
+            DateTime currentStart = start;
+            while (currentStart < end)
+            {
+                DateTime currentEnd = currentStart.AddDays(dayRange);
+                if (currentEnd > end)
+                {
+                    currentEnd = end;
+                }
+
+                Task<List<NetworkData>> task = getDataFunction(interval, currentStart, currentEnd, cancellationToken);
+                tasks.Add(task);
+                currentStart = currentEnd;
+            }
+
+            List<NetworkData>[]? results = await Task.WhenAll(tasks);
+            return [.. results.SelectMany(r => r)];
+        }
+    }
+}

--- a/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
+++ b/OpenElectricity.Sdk/Client/OpenElectricityClientExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using OpenElectricity.Sdk.Types;
+using System.Runtime.CompilerServices;
 
 namespace OpenElectricity.Sdk.Client
 {
@@ -21,7 +22,7 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public static async Task<List<NetworkData>> GetMarketDataForDateRangeAsync(
+        public static async IAsyncEnumerable<List<NetworkData>> GetMarketDataForDateRangeAsync(
             this OpenElectricityClient client,
             NetworkCode networkCode,
             List<MarketMetric> metrics,
@@ -30,11 +31,10 @@ namespace OpenElectricity.Sdk.Client
             DateTime dateEnd,
             DataPrimaryGrouping? primaryGrouping = null,
             bool withClerk = true,
-            CancellationToken cancellationToken = default
-
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
             )
         {
-            return await GetAllForDateRangeAsync((inter, start, end, token) =>
+            var enumerator = GetAllForDateRangeAsync((inter, start, end, token) =>
             {
                 return client.GetMarketDataAsync(
                     networkCode, metrics, inter, start, end,
@@ -42,6 +42,11 @@ namespace OpenElectricity.Sdk.Client
                     token);
             },
             interval, dateStart, dateEnd, cancellationToken);
+
+            await foreach (var page in enumerator)
+            {
+                yield return page;
+            }
         }
 
         /// <summary>
@@ -59,7 +64,7 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public static async Task<List<NetworkData>> GetGenerationDataForDateRangeAsync(
+        public static async IAsyncEnumerable<List<NetworkData>> GetGenerationDataForDateRangeAsync(
             this OpenElectricityClient client,
             NetworkCode networkCode,
             List<DataMetric> metrics,
@@ -69,11 +74,10 @@ namespace OpenElectricity.Sdk.Client
             DataPrimaryGrouping? primaryGrouping = null,
             DataSecondaryGrouping? secondaryGrouping = null,
             bool withClerk = true,
-            CancellationToken cancellationToken = default
-
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
             )
         {
-            return await GetAllForDateRangeAsync((inter, start, end, token) =>
+            var enumerator = GetAllForDateRangeAsync((inter, start, end, token) =>
             {
                 return client.GetGenerationDataAsync(
                     networkCode, metrics, inter, start, end,
@@ -81,6 +85,11 @@ namespace OpenElectricity.Sdk.Client
                     token);
             },
             interval, dateStart, dateEnd, cancellationToken);
+
+            await foreach(var page in enumerator)
+            {
+                yield return page;
+            }
         }
 
         /// <summary>
@@ -96,7 +105,7 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="withClerk"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<List<NetworkData>> GetFacilityDataForDateRangeAsync(
+        public static async IAsyncEnumerable<List<NetworkData>> GetFacilityDataForDateRangeAsync(
             this OpenElectricityClient client,
             NetworkCode networkCode,
             List<DataMetric> metrics,
@@ -105,11 +114,10 @@ namespace OpenElectricity.Sdk.Client
             DateTime dateEnd,
             List<string>? facilityCodes = null,
             bool withClerk = true,
-            CancellationToken cancellationToken = default
-
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
             )
         {
-            return await GetAllForDateRangeAsync((inter, start, end, token) =>
+            var enumerator = GetAllForDateRangeAsync((inter, start, end, token) =>
             {
                 return client.GetFacilityDataAsync(
                     networkCode, metrics, inter, facilityCodes, 
@@ -117,6 +125,11 @@ namespace OpenElectricity.Sdk.Client
                     token);
             },
             interval, dateStart, dateEnd, cancellationToken);
+
+            await foreach (var page in enumerator)
+            {
+                yield return page;
+            }
         }
 
         /// <summary>
@@ -129,12 +142,12 @@ namespace OpenElectricity.Sdk.Client
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public static async Task<List<NetworkData>> GetAllForDateRangeAsync(
+        public static async IAsyncEnumerable<List<NetworkData>> GetAllForDateRangeAsync(
             Func<DataInterval, DateTime, DateTime, CancellationToken, Task<List<NetworkData>>> getDataFunction,
             DataInterval interval,
             DateTime start,
             DateTime end,
-            CancellationToken cancellationToken = default
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
             )
         {
             int dayRange = interval.DayRange() ?? throw new Exception($"Day range for interval {interval} is invalid");
@@ -158,12 +171,10 @@ namespace OpenElectricity.Sdk.Client
                 currentStart = currentEnd;
             }
 
-            List<NetworkData>[]? results = await Task.WhenAll(tasks);
-
-            // BUG: Currently this just combines the responses of all the separate requests into a list
-            // EXPECTED: Combines List<TimeValue> together based on NetworkData.NetworkCode + NetworkData.Groupings + TimeSeriesResult.Name + TimeSeriesResult.Columns
-
-            return [.. results.SelectMany(r => r)];
+            await foreach(var response in Task.WhenEach(tasks))
+            {
+                yield return await response;
+            }
         }
     }
 }

--- a/OpenElectricity.Sdk/Types/Enums.cs
+++ b/OpenElectricity.Sdk/Types/Enums.cs
@@ -267,6 +267,11 @@ namespace OpenElectricity.Sdk.Types
         announced,
 
         /// <summary>
+        /// Under Construction
+        /// </summary>
+        committed,
+
+        /// <summary>
         /// Being tested
         /// </summary>
         commissioning,


### PR DESCRIPTION
OpenElectricity does not use standard pagination for the data.

Instead, the amount of data retrieved depends on the time difference between the _start_date_ and _end_date_ parameters, as well as the _interval_ parameter.

These extension functions have been added to simplify the process of splitting the requested time range into multiple requests.

Just as the default functions return a Task that must be handled by the user, these functions instead return a Collection of Tasks that must be handled by the user.

This PR also includes some minor refactoring to help with maintaining the deserialization process.

Also add an enum value that was missing before.